### PR TITLE
Support lower minimum version: Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = []
 
 description = "Simple statically-typed unit of measurements with order conversions."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 lint = ["black", "ruff"]

--- a/src/stuom/length.py
+++ b/src/stuom/length.py
@@ -1,5 +1,5 @@
 """Units of measurement for working with lengths."""
-from typing import Self, TypeVar
+from typing import TypeVar
 
 from stuom.uom import HasSiOrder
 
@@ -13,7 +13,7 @@ class Length(HasSiOrder):
         return self.convert_si(to_cls)
 
     @classmethod
-    def from_length(cls, other: "Length") -> Self:
+    def from_length(cls: type[LengthT], other: "Length") -> LengthT:
         return other.convert_length(cls)
 
 

--- a/src/stuom/parse.py
+++ b/src/stuom/parse.py
@@ -1,6 +1,5 @@
 """Functions for parsing `Duration`s from strings."""
 
-
 from stuom.duration import (
     Duration,
     Hours,

--- a/src/stuom/uom.py
+++ b/src/stuom/uom.py
@@ -1,7 +1,7 @@
 """Simple statically-typed unit of measurements with order conversions."""
 
 from abc import abstractmethod
-from typing import Self, TypeVar
+from typing import TypeVar
 
 SiT = TypeVar("SiT", bound="HasSiOrder")
 
@@ -19,7 +19,7 @@ class HasSiOrder(float):
         return _convert_si(self, to_cls)
 
     @classmethod
-    def from_si(cls, other: "HasSiOrder") -> Self:
+    def from_si(cls: type[SiT], other: "HasSiOrder") -> SiT:
         return other.convert_si(cls)
 
 


### PR DESCRIPTION
- It is quite easy to extend support for Python 3.10 by removing the use of `typing.Self`.