### PR TITLE
Add unit-specific conversion methods

### DIFF
--- a/src/stuom/electricity.py
+++ b/src/stuom/electricity.py
@@ -1,9 +1,20 @@
 """Contains units of measurement for working with electricity units such as power."""
+from typing import TypeVar
+
 from stuom.uom import HasSiOrder
+
+PotentialT = TypeVar("PotentialT", bound="ElectricPotential")
 
 
 class ElectricPotential(HasSiOrder):
     """A unit of measurement representing electric potential."""
+
+    def convert_potential(self, to_cls: type[PotentialT]) -> PotentialT:
+        return self.convert_si(to_cls)
+
+    @classmethod
+    def from_potential(cls: type[PotentialT], other: "ElectricPotential") -> PotentialT:
+        return other.convert_potential(cls)
 
 
 class Kilovolts(ElectricPotential):
@@ -39,10 +50,18 @@ class Millivolts(ElectricPotential):
         return 3
 
 
+PowerT = TypeVar("PowerT", bound="Power")
+
+
 class Power(HasSiOrder):
     """The amount of energy transferred per unit time."""
 
-    pass
+    def convert_power(self, to_cls: type[PowerT]) -> PowerT:
+        return self.convert_si(to_cls)
+
+    @classmethod
+    def from_power(cls: type[PowerT], other: "Power") -> PowerT:
+        return other.convert_power(cls)
 
 
 class Watts(Power):
@@ -84,8 +103,18 @@ class Milliwatts(Power):
         return 3
 
 
+CurrentT = TypeVar("CurrentT", bound="Current")
+
+
 class Current(HasSiOrder):
     """A unit of measurement representing electric current."""
+
+    def convert_current(self, to_cls: type[CurrentT]) -> CurrentT:
+        return self.convert_si(to_cls)
+
+    @classmethod
+    def from_current(cls: type[CurrentT], other: "Current") -> CurrentT:
+        return other.convert_current(cls)
 
 
 class Amps(Current):

--- a/src/stuom/length.py
+++ b/src/stuom/length.py
@@ -80,11 +80,22 @@ class Angstroms(Length):
         return 10
 
 
+ReciprocalLengthT = TypeVar("ReciprocalLengthT", bound="ReciprocalLength")
+
+
 class ReciprocalLength(HasSiOrder):
     """1 / `Length`."""
 
-    # def reciprocate(self) -> HasSiOrder:
-    #     return Length()
+    def convert_from_reciprocal_length(
+        self, to_cls: type[ReciprocalLengthT]
+    ) -> ReciprocalLengthT:
+        return self.convert_si(to_cls)
+
+    @classmethod
+    def from_reciprocal_length(
+        cls: type[ReciprocalLengthT], other: "ReciprocalLength"
+    ) -> ReciprocalLengthT:
+        return other.convert_from_reciprocal_length(cls)
 
 
 class ReciprocalMeters(ReciprocalLength):

--- a/tests/test_uom.py
+++ b/tests/test_uom.py
@@ -64,18 +64,18 @@ def test_length_uom():
     assert math.isclose(Meters(0.005), Milimeters(5).convert_length(Meters))
     assert math.isclose(Meters(1), Meters.from_length(Milimeters(1000)))
     assert math.isclose(Meters(2), Meters.from_length(Angstroms.from_length(Meters(2))))
-    assert math.isclose(Meters(2).convert_si(Angstroms), Angstroms(2e10))
-    assert math.isclose(Angstroms(2e10).convert_si(Meters), Meters(2))
+    assert math.isclose(Meters(2).convert_length(Angstroms), Angstroms(2e10))
+    assert math.isclose(Angstroms(2e10).convert_length(Meters), Meters(2))
 
     assert math.isclose(
         ReciprocalMeters(10e-2)
-        .convert_si(ReciprocalCentimeters)
-        .convert_si(ReciprocalMeters),
+        .convert_from_reciprocal_length(ReciprocalCentimeters)
+        .convert_from_reciprocal_length(ReciprocalMeters),
         ReciprocalMeters(10e-2),
     )
 
     assert math.isclose(
-        ReciprocalMeters(1).convert_si(ReciprocalCentimeters),
+        ReciprocalMeters(1).convert_from_reciprocal_length(ReciprocalCentimeters),
         ReciprocalCentimeters(100),
     )
 
@@ -85,7 +85,9 @@ def test_length_uom():
 def test_electricity_uom():
     power = Watts.from_current_and_potential(Microamps(225), Kilovolts(20))
     assert power == Watts(4.5)
-    assert Deciwatts.from_si(power) == 45
+    assert Deciwatts.from_power(power) == 45
+    assert Volts.from_potential(Kilovolts(20)) == Volts(20000)
+    assert Amps.from_current(Microamps(225)) == Amps(0.000225)
 
 
 def test_uom_str_representations():


### PR DESCRIPTION
- This will make it more clear which function to use, when looking at code auto-completion.
- Also add tests to make sure these conversion functions delegate to `HasSiOrder.convert_si`.