### PR TITLE
Add international standard units of measurement for measuring computer memory size 

### DIFF
--- a/src/stuom/memory_size/__init__.py
+++ b/src/stuom/memory_size/__init__.py
@@ -1,0 +1,4 @@
+"""Units of measurement for working with computer memory sizes."""
+
+from .memory_size import MemorySize, Bytes  # noqa: I001
+

--- a/src/stuom/memory_size/__init__.py
+++ b/src/stuom/memory_size/__init__.py
@@ -1,4 +1,5 @@
 """Units of measurement for working with computer memory sizes."""
 
 from .memory_size import MemorySize, Bytes  # noqa: I001
+from .decimal_memory_size import KiloBytes, MegaBytes, GigaBytes, TeraBytes, PetaBytes# noqa: I001
 

--- a/src/stuom/memory_size/__init__.py
+++ b/src/stuom/memory_size/__init__.py
@@ -2,4 +2,5 @@
 
 from .memory_size import MemorySize, Bytes  # noqa: I001
 from .decimal_memory_size import KiloBytes, MegaBytes, GigaBytes, TeraBytes, PetaBytes# noqa: I001
+from .binary_memory_size import KibiBytes, MebiBytes, GibiBytes, TebiBytes, PebiBytes# noqa: I001
 

--- a/src/stuom/memory_size/__init__.py
+++ b/src/stuom/memory_size/__init__.py
@@ -1,6 +1,17 @@
 """Units of measurement for working with computer memory sizes."""
 
 from .memory_size import MemorySize, Bytes  # noqa: I001
-from .decimal_memory_size import KiloBytes, MegaBytes, GigaBytes, TeraBytes, PetaBytes# noqa: I001
-from .binary_memory_size import KibiBytes, MebiBytes, GibiBytes, TebiBytes, PebiBytes# noqa: I001
-
+from .decimal_memory_size import (
+    KiloBytes,
+    MegaBytes,
+    GigaBytes,
+    TeraBytes,
+    PetaBytes,
+)  # noqa: I001
+from .binary_memory_size import (
+    KibiBytes,
+    MebiBytes,
+    GibiBytes,
+    TebiBytes,
+    PebiBytes,
+)  # noqa: I001

--- a/src/stuom/memory_size/binary_memory_size.py
+++ b/src/stuom/memory_size/binary_memory_size.py
@@ -52,6 +52,7 @@ class TebiBytes(MemorySize):
     def order() -> float:
         return -math.log(2**40, 10)
 
+
 class PebiBytes(MemorySize):
     """2^50 bytes."""
 

--- a/src/stuom/memory_size/binary_memory_size.py
+++ b/src/stuom/memory_size/binary_memory_size.py
@@ -1,0 +1,63 @@
+"""Contains computer memory size units of memory size following the EIC binary convention.
+
+The current implementation of these units incurs some added floating-point error. The reason this
+occurs is simply because the uom.py module implements SI conversions using a base-10 exponent.
+"""
+
+import math
+
+from stuom.memory_size.memory_size import MemorySize
+
+
+class KibiBytes(MemorySize):
+    """2^10 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " kiB"
+
+    @staticmethod
+    def order() -> float:
+        return -math.log(2**10, 10)
+
+
+class MebiBytes(MemorySize):
+    """2^20 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " MiB"
+
+    @staticmethod
+    def order() -> float:
+        return -math.log(2**20, 10)
+
+
+class GibiBytes(MemorySize):
+    """2^30 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " GiB"
+
+    @staticmethod
+    def order() -> float:
+        return -math.log(2**30, 10)
+
+
+class TebiBytes(MemorySize):
+    """2^40 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " TiB"
+
+    @staticmethod
+    def order() -> float:
+        return -math.log(2**40, 10)
+
+class PebiBytes(MemorySize):
+    """2^50 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " PiB"
+
+    @staticmethod
+    def order() -> float:
+        return -math.log(2**50, 10)

--- a/src/stuom/memory_size/decimal_memory_size.py
+++ b/src/stuom/memory_size/decimal_memory_size.py
@@ -46,6 +46,7 @@ class TeraBytes(MemorySize):
     def order() -> int:
         return -12
 
+
 class PetaBytes(MemorySize):
     """1_000_000_000_000 bytes."""
 

--- a/src/stuom/memory_size/decimal_memory_size.py
+++ b/src/stuom/memory_size/decimal_memory_size.py
@@ -1,0 +1,57 @@
+"""Contains computer memory size units of memory size following the EIC decimal convention."""
+
+from stuom.memory_size.memory_size import MemorySize
+
+
+class KiloBytes(MemorySize):
+    """1_000 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " kB"
+
+    @staticmethod
+    def order() -> int:
+        return -3
+
+
+class MegaBytes(MemorySize):
+    """1_000_000 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " MB"
+
+    @staticmethod
+    def order() -> int:
+        return -6
+
+
+class GigaBytes(MemorySize):
+    """1_000_000_000 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " GB"
+
+    @staticmethod
+    def order() -> int:
+        return -9
+
+
+class TeraBytes(MemorySize):
+    """1_000_000_000_000 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " TB"
+
+    @staticmethod
+    def order() -> int:
+        return -12
+
+class PetaBytes(MemorySize):
+    """1_000_000_000_000 bytes."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " PB"
+
+    @staticmethod
+    def order() -> int:
+        return -15

--- a/src/stuom/memory_size/memory_size.py
+++ b/src/stuom/memory_size/memory_size.py
@@ -6,6 +6,7 @@ from stuom.uom import HasSiOrder
 
 MemorySizeT = TypeVar("MemorySizeT", bound="MemorySize")
 
+
 class MemorySize(HasSiOrder):
     """Represents a byte-based unit of measuring memory size.
 
@@ -18,7 +19,6 @@ class MemorySize(HasSiOrder):
 
     def convert_memmory_size(self, to_cls: type[MemorySizeT]) -> MemorySizeT:
         return self.convert_si(to_cls)
-
 
     @classmethod
     def from_memory_size(cls: type[MemorySizeT], other: "MemorySize") -> MemorySizeT:

--- a/src/stuom/memory_size/memory_size.py
+++ b/src/stuom/memory_size/memory_size.py
@@ -1,0 +1,36 @@
+"""Units of measurement base class for working with computer memory sizes."""
+
+from typing import TypeVar
+
+from stuom.uom import HasSiOrder
+
+MemorySizeT = TypeVar("MemorySizeT", bound="MemorySize")
+
+class MemorySize(HasSiOrder):
+    """Represents a byte-based unit of measuring memory size.
+
+    Note that there are two standards for describing computer memory size. One is the International
+    System of Units (SI) definition, in which the decimal number system is used: 1000 bytes is
+    kilobytes (kB). The other is binary-based, in where 1024 bytes is 1 KB. The IEC recommends the
+    use of Kibi as a prefix in place of Kilo however. We intend to follow the IEC80000-13
+    international standard on this matter and distinguish KiloBytes vs. KibiBytes.
+    """
+
+    def convert_memmory_size(self, to_cls: type[MemorySizeT]) -> MemorySizeT:
+        return self.convert_si(to_cls)
+
+
+    @classmethod
+    def from_memory_size(cls: type[MemorySizeT], other: "MemorySize") -> MemorySizeT:
+        return other.convert_memmory_size(cls)
+
+
+class Bytes(MemorySize):
+    """8 bits."""
+
+    def __str__(self) -> str:
+        return super().__str__() + " B"
+
+    @staticmethod
+    def order() -> int:
+        return 0

--- a/src/stuom/parse.py
+++ b/src/stuom/parse.py
@@ -36,7 +36,7 @@ def find_minimal_si(d: Duration) -> Duration:
 
 
 def parse_minimal_si(d: Duration) -> str:
-    """Parse the minimal duration subclass.
+    """String format a duration into its minimum-order SI duration.
 
     Args:
         d (Duration): The duration to process.

--- a/src/stuom/parse.py
+++ b/src/stuom/parse.py
@@ -13,14 +13,15 @@ from stuom.duration import (
 
 
 def find_minimal_si(d: Duration) -> Duration:
-    """Parse the duration and use the `Duration` subclass that represents the duration in the
-    lowest number of digits.
+    """Find the given duration's minimum-order SI type that minimizes the number of digits needed
+    to represent the given value.
 
     Args:
         d (Duration): The duration to parse
 
     Returns:
-        str: The
+        Duration: A duration that minimizes the number of digits needed to represent the given
+        value.
     """
     duration_us = d.convert_duration(Microseconds)
     duration_ms = d.convert_duration(Milliseconds)

--- a/tests/memory_size/test_binary_memory_sizes.py
+++ b/tests/memory_size/test_binary_memory_sizes.py
@@ -1,35 +1,51 @@
 """Test computer memory size units of measurement following the IEC binary convention."""
 
 import pytest
-from stuom.memory_size import Bytes, GibiBytes, KibiBytes, MebiBytes, PebiBytes, TebiBytes
+from stuom.memory_size import (
+    Bytes,
+    GibiBytes,
+    KibiBytes,
+    MebiBytes,
+    PebiBytes,
+    TebiBytes,
+)
 
 
 def test_bytes_to_kibibytes_conversion():
     assert KibiBytes.from_memory_size(Bytes(2**10)) == pytest.approx(KibiBytes(1))
 
+
 def test_bytes_to_mebibytes_conversion():
     assert MebiBytes.from_memory_size(Bytes(2**20)) == pytest.approx(MebiBytes(1))
+
 
 def test_bytes_to_gibibytes_conversion():
     assert GibiBytes.from_memory_size(Bytes(2**30)) == pytest.approx(GibiBytes(1))
 
+
 def test_bytes_to_tebibytes_conversion():
     assert TebiBytes.from_memory_size(Bytes(2**40)) == pytest.approx(TebiBytes(1))
+
 
 def test_bytes_to_pebibytes_conversion():
     assert PebiBytes.from_memory_size(Bytes(2**50)) == pytest.approx(PebiBytes(1))
 
+
 def test_string_format_kibibytes():
     assert str(KibiBytes(20)) == "20.0 kiB"
+
 
 def test_string_format_mebibytes():
     assert str(MebiBytes(20)) == "20.0 MiB"
 
+
 def test_string_format_gibibytes():
     assert str(GibiBytes(20)) == "20.0 GiB"
 
+
 def test_string_format_tebibytes():
     assert str(TebiBytes(20)) == "20.0 TiB"
+
 
 def test_string_format_pebibytes():
     assert str(PebiBytes(20)) == "20.0 PiB"

--- a/tests/memory_size/test_binary_memory_sizes.py
+++ b/tests/memory_size/test_binary_memory_sizes.py
@@ -1,0 +1,21 @@
+"""Test computer memory size units of measurement following the IEC binary convention."""
+
+import pytest
+from stuom.memory_size import Bytes, GibiBytes, KibiBytes, MebiBytes, PebiBytes, TebiBytes
+
+
+def test_bytes_to_kibibytes_conversion():
+    assert KibiBytes.from_memory_size(Bytes(2**10)) == pytest.approx(KibiBytes(1))
+
+def test_bytes_to_mebibytes_conversion():
+    assert MebiBytes.from_memory_size(Bytes(2**20)) == pytest.approx(MebiBytes(1))
+
+def test_bytes_to_gibibytes_conversion():
+    assert GibiBytes.from_memory_size(Bytes(2**30)) == pytest.approx(GibiBytes(1))
+
+def test_bytes_to_tebibytes_conversion():
+    assert TebiBytes.from_memory_size(Bytes(2**40)) == pytest.approx(TebiBytes(1))
+
+def test_bytes_to_pebibytes_conversion():
+    assert PebiBytes.from_memory_size(Bytes(2**50)) == pytest.approx(PebiBytes(1))
+

--- a/tests/memory_size/test_binary_memory_sizes.py
+++ b/tests/memory_size/test_binary_memory_sizes.py
@@ -19,3 +19,17 @@ def test_bytes_to_tebibytes_conversion():
 def test_bytes_to_pebibytes_conversion():
     assert PebiBytes.from_memory_size(Bytes(2**50)) == pytest.approx(PebiBytes(1))
 
+def test_string_format_kibibytes():
+    assert str(KibiBytes(20)) == "20.0 kiB"
+
+def test_string_format_mebibytes():
+    assert str(MebiBytes(20)) == "20.0 MiB"
+
+def test_string_format_gibibytes():
+    assert str(GibiBytes(20)) == "20.0 GiB"
+
+def test_string_format_tebibytes():
+    assert str(TebiBytes(20)) == "20.0 TiB"
+
+def test_string_format_pebibytes():
+    assert str(PebiBytes(20)) == "20.0 PiB"

--- a/tests/memory_size/test_cross_conversions.py
+++ b/tests/memory_size/test_cross_conversions.py
@@ -1,0 +1,39 @@
+"""Test computer memory size units of measurement."""
+
+import pytest
+from stuom.memory_size import (
+    GigaBytes,
+    KibiBytes,
+    KiloBytes,
+    MegaBytes,
+    PetaBytes,
+    TeraBytes,
+)
+
+
+def test_bytes_to_kilobytes_conversion():
+    assert KiloBytes.from_memory_size(KibiBytes(1)) == pytest.approx(KiloBytes(1.024))
+
+
+def test_bytes_to_megabytes_conversion():
+    assert MegaBytes.from_memory_size(KibiBytes(1)) == pytest.approx(
+        MegaBytes(1.024e-3)
+    )
+
+
+def test_bytes_to_gigabytes_conversion():
+    assert GigaBytes.from_memory_size(KibiBytes(1)) == pytest.approx(
+        GigaBytes(1.024e-6)
+    )
+
+
+def test_bytes_to_terabytes_conversion():
+    assert TeraBytes.from_memory_size(KibiBytes(1)) == pytest.approx(
+        TeraBytes(1.024e-9)
+    )
+
+
+def test_bytes_to_petabytes_conversion():
+    assert PetaBytes.from_memory_size(KibiBytes(1)) == pytest.approx(
+        PetaBytes(1.024e-12)
+    )

--- a/tests/memory_size/test_decimal_memory_sizes.py
+++ b/tests/memory_size/test_decimal_memory_sizes.py
@@ -17,3 +17,18 @@ def test_bytes_to_terabytes_conversion():
 
 def test_bytes_to_petabytes_conversion():
     assert PetaBytes.from_memory_size(Bytes(1e15)) == PetaBytes(1)
+
+def test_string_format_kilobytes():
+    assert str(KiloBytes(20)) == "20.0 kB"
+
+def test_string_format_megabytes():
+    assert str(MegaBytes(20)) == "20.0 MB"
+
+def test_string_format_gigabytes():
+    assert str(GigaBytes(20)) == "20.0 GB"
+
+def test_string_format_terabytes():
+    assert str(TeraBytes(20)) == "20.0 TB"
+
+def test_string_format_petabytes():
+    assert str(PetaBytes(20)) == "20.0 PB"

--- a/tests/memory_size/test_decimal_memory_sizes.py
+++ b/tests/memory_size/test_decimal_memory_sizes.py
@@ -1,34 +1,50 @@
 """Test computer memory size units of measurement."""
 
-from stuom.memory_size import Bytes, GigaBytes, KiloBytes, MegaBytes, PetaBytes, TeraBytes
+from stuom.memory_size import (
+    Bytes,
+    GigaBytes,
+    KiloBytes,
+    MegaBytes,
+    PetaBytes,
+    TeraBytes,
+)
 
 
 def test_bytes_to_kilobytes_conversion():
     assert KiloBytes.from_memory_size(Bytes(1e3)) == KiloBytes(1)
 
+
 def test_bytes_to_megabytes_conversion():
     assert MegaBytes.from_memory_size(Bytes(1e6)) == MegaBytes(1)
+
 
 def test_bytes_to_gigabytes_conversion():
     assert GigaBytes.from_memory_size(Bytes(1e9)) == GigaBytes(1)
 
+
 def test_bytes_to_terabytes_conversion():
     assert TeraBytes.from_memory_size(Bytes(1e12)) == TeraBytes(1)
+
 
 def test_bytes_to_petabytes_conversion():
     assert PetaBytes.from_memory_size(Bytes(1e15)) == PetaBytes(1)
 
+
 def test_string_format_kilobytes():
     assert str(KiloBytes(20)) == "20.0 kB"
+
 
 def test_string_format_megabytes():
     assert str(MegaBytes(20)) == "20.0 MB"
 
+
 def test_string_format_gigabytes():
     assert str(GigaBytes(20)) == "20.0 GB"
 
+
 def test_string_format_terabytes():
     assert str(TeraBytes(20)) == "20.0 TB"
+
 
 def test_string_format_petabytes():
     assert str(PetaBytes(20)) == "20.0 PB"

--- a/tests/memory_size/test_decimal_memory_sizes.py
+++ b/tests/memory_size/test_decimal_memory_sizes.py
@@ -1,0 +1,19 @@
+"""Test computer memory size units of measurement."""
+
+from stuom.memory_size import Bytes, GigaBytes, KiloBytes, MegaBytes, PetaBytes, TeraBytes
+
+
+def test_bytes_to_kilobytes_conversion():
+    assert KiloBytes.from_memory_size(Bytes(1e3)) == KiloBytes(1)
+
+def test_bytes_to_megabytes_conversion():
+    assert MegaBytes.from_memory_size(Bytes(1e6)) == MegaBytes(1)
+
+def test_bytes_to_gigabytes_conversion():
+    assert GigaBytes.from_memory_size(Bytes(1e9)) == GigaBytes(1)
+
+def test_bytes_to_terabytes_conversion():
+    assert TeraBytes.from_memory_size(Bytes(1e12)) == TeraBytes(1)
+
+def test_bytes_to_petabytes_conversion():
+    assert PetaBytes.from_memory_size(Bytes(1e15)) == PetaBytes(1)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -14,9 +14,9 @@ from stuom.parse import find_minimal_si, parse_duration, parse_minimal_si
 
 
 def test_parse_minimal_si():
-    assert type(find_minimal_si(Milliseconds(0.05))) == Microseconds
-    assert type(find_minimal_si(Milliseconds(5000))) == Seconds
-    assert type(find_minimal_si(Milliseconds(5))) == Milliseconds
+    assert type(find_minimal_si(Milliseconds(0.05))) is Microseconds
+    assert type(find_minimal_si(Milliseconds(5000))) is Seconds
+    assert type(find_minimal_si(Milliseconds(5))) is Milliseconds
     assert parse_minimal_si(Milliseconds(0.05)) == "50.0us"
     assert parse_minimal_si(Milliseconds(5000)) == "5.0s"
     assert parse_minimal_si(Seconds(0.01)) == "10.0ms"


### PR DESCRIPTION
This pull request adds the usual bytes, kilobytes, megabytes, etc units of measurement in the `stuom.memory_size.decimal_memory_size` module. These units are a little more nuanced in that there are a [few different conventions](https://en.wikipedia.org/wiki/Kilobyte#Definitions_and_usage) mentioned by the international standards. It seems like the main distinction is that of using the decimal or binary number system as the base. The decimal-based convention is the one recommended by the international standards as outlined in [IEC 80000-13](https://www.iso.org/standard/31898.html), however the binary-based convention is still commonly found, and is [prevalent in the Windows operating system](https://web.archive.org/web/20140209012305/http://support.microsoft.com/kb/121839).

The binary-based "KibiBytes" convention is also included in the `stuom.memory_size.binary_memory_size` module.

This PR resolves issue #10.