### PR TITLE
Add optional pydantic validation support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
   pull_request:
-    branches: [main]
+    types: [opened]
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,11 @@ on:
     branches: [main]
 
   pull_request:
-    types: [ready_for_review]
+    types:
+      - ready_for_review
+    branches:
+      - dev/*
+      - main
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        pydantic-version: ["~=2.6.0", "~=2.7.0", "~=2.8.0"]
+        pydantic-version-install:
+          - "pip install pydantic~=2.6.0"
+          - "pip install pydantic~=2.7.0"
+          - "pip install pydantic~=2.8.0"
+          - "echo 'No pydantic install'"
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
@@ -54,7 +58,7 @@ jobs:
         run: pip install .'[dev]'
 
       - name: Install specific version of pydantic
-        run: pip install pydantic${{ matrix.pydantic-version }}
+        run: ${{ matrix.pydantic-version-install }}
 
       - name: Run tests
         run: pytest -s -vvvv -l --tb=long tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,8 @@ on:
 
   pull_request:
     types:
-      - ready_for_review
+      - ready_for_review # Run CI when PR is marked as ready for review.
+      - synchronize # Run CI when HEAD is updated (i.e., new commit was pushed).
     branches:
       - dev/*
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,13 @@ jobs:
       - name: Run linter
         run: ruff check src/stuom
 
-  tests_linux:
+  tests_bash_shell:
     needs: linter
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
+        pydantic-version: ["~=2.6.0", "~=2.7.0", "~=2.8.0"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
@@ -47,6 +48,9 @@ jobs:
 
       - name: Install project
         run: pip install .'[dev]'
+
+      - name: Install specific version of pydantic
+        run: pip install pydantic${{ matrix.pydantic-version }}
 
       - name: Run tests
         run: pytest -s -vvvv -l --tb=long tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
   pull_request:
-    types: [opened]
+    types: [ready_for_review]
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,6 @@ jobs:
       - name: Run tests
         run: pytest -s -vvvv -l --tb=long tests
 
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v3
-        # with:
-        #   fail_ci_if_error: true
-
   tests_mac:
     needs: linter
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,26 +51,6 @@ jobs:
       - name: Run tests
         run: pytest -s -vvvv -l --tb=long tests
 
-  tests_mac:
-    needs: linter
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10"]
-        os: [macos-latest]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install project
-        run: pip install .'[dev]'
-
-      - name: Run tests
-        run: pytest -s -vvvv -l --tb=long tests
-
   tests_win:
     needs: linter
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = ["black~=24.4.0", "ruff~=0.5.0", "pytest~=8.2.0", "pytest-cov~=5.0.0"]
+pydantic = ["pydantic~=2.6"]
 
 [tool.pylint]
 max-line-length = 100

--- a/src/stuom/uom.py
+++ b/src/stuom/uom.py
@@ -59,6 +59,7 @@ class HasSiOrder(float):
         return self_type(float.__floordiv__(self, value))
 
     if HAS_PYDANTIC_CORE:
+
         @classmethod
         def validate(cls, value, _):
             if not isinstance(value, float):
@@ -69,9 +70,9 @@ class HasSiOrder(float):
         @classmethod
         def __get_pydantic_json_schema__(
             cls,
-            schema: core_schema.CoreSchema, # type: ignore
-            handler: Callable[[Any], core_schema.CoreSchema], # type: ignore
-        ) -> core_schema.CoreSchema: # type: ignore
+            schema: core_schema.CoreSchema,  # type: ignore
+            handler: Callable[[Any], core_schema.CoreSchema],  # type: ignore
+        ) -> core_schema.CoreSchema:  # type: ignore
             return handler(core_schema.float_schema())
 
         @classmethod

--- a/tests/test_uom_pydantic.py
+++ b/tests/test_uom_pydantic.py
@@ -1,0 +1,21 @@
+"""Test that we can create basic pydantic models using units of measurement."""
+
+import pytest
+from stuom.duration import Seconds
+
+try:
+    from pydantic import BaseModel  # type: ignore
+
+except (ImportError, ModuleNotFoundError):
+    pytest.skip(allow_module_level=True)
+
+
+def test_duration_fields_work_in_pydantic_models():
+    """This ensures that one can construct pydantic `BaseModel`s with the `Duration` units of
+    measurement.
+    """
+    class TestModel(BaseModel):
+        duration: Seconds
+
+    TestModel(duration=Seconds(2))
+

--- a/tests/test_uom_pydantic.py
+++ b/tests/test_uom_pydantic.py
@@ -14,8 +14,8 @@ def test_duration_fields_work_in_pydantic_models():
     """This ensures that one can construct pydantic `BaseModel`s with the `Duration` units of
     measurement.
     """
+
     class TestModel(BaseModel):
         duration: Seconds
 
     TestModel(duration=Seconds(2))
-


### PR DESCRIPTION
This pull request resolves issue #11 and adds basic float validation for pydantic data models. In particular it allows one to create classes derived from `BaseModel` with `stuom` fields.