### PR TITLE
Standard units of measurement version 0.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,12 @@ on:
     branches: [main]
 
   pull_request:
-    branches: [main]
+    types:
+      - ready_for_review # Run CI when PR is marked as ready for review.
+      - synchronize # Run CI when HEAD is updated (i.e., new commit was pushed).
+    branches:
+      - dev/*
+      - main
 
   workflow_dispatch:
 
@@ -30,12 +35,17 @@ jobs:
       - name: Run linter
         run: ruff check src/stuom
 
-  tests_linux:
+  tests_bash_shell:
     needs: linter
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
+        pydantic-version-install:
+          - "pip install pydantic~=2.6.0"
+          - "pip install pydantic~=2.7.0"
+          - "pip install pydantic~=2.8.0"
+          - "echo 'No pydantic install'"
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
@@ -48,30 +58,8 @@ jobs:
       - name: Install project
         run: pip install .'[dev]'
 
-      - name: Run tests
-        run: pytest -s -vvvv -l --tb=long tests
-
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v3
-        # with:
-        #   fail_ci_if_error: true
-
-  tests_mac:
-    needs: linter
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10"]
-        os: [macos-latest]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install project
-        run: pip install .'[dev]'
+      - name: Install specific version of pydantic
+        run: ${{ matrix.pydantic-version-install }}
 
       - name: Run tests
         run: pytest -s -vvvv -l --tb=long tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stuom"
-version = "0.1.0"
+version = "0.2.0"
 authors = [{ name = "Shaun Ostoic", email = "ostoic@proton.me" }]
 
 dependencies = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = ["black~=24.4.0", "ruff~=0.5.0", "pytest~=8.2.0", "pytest-cov~=5.0.0"]
+pydantic = ["pydantic~=2.6"]
 
 [tool.pylint]
 max-line-length = 100

--- a/src/stuom/__init__.py
+++ b/src/stuom/__init__.py
@@ -36,3 +36,17 @@ from .length import (
     ReciprocalMicrometers,
     ReciprocalMilimeters,
 )
+from .memory_size import (
+    Bytes,
+    GibiBytes,
+    GigaBytes,
+    KibiBytes,
+    KiloBytes,
+    MebiBytes,
+    MegaBytes,
+    MemorySize,
+    PebiBytes,
+    PetaBytes,
+    TebiBytes,
+    TeraBytes,
+)

--- a/src/stuom/memory_size/__init__.py
+++ b/src/stuom/memory_size/__init__.py
@@ -1,17 +1,17 @@
 """Units of measurement for working with computer memory sizes."""
 
-from .memory_size import MemorySize, Bytes  # noqa: I001
-from .decimal_memory_size import (
-    KiloBytes,
-    MegaBytes,
-    GigaBytes,
-    TeraBytes,
-    PetaBytes,
-)  # noqa: I001
 from .binary_memory_size import (
+    GibiBytes,
     KibiBytes,
     MebiBytes,
-    GibiBytes,
-    TebiBytes,
     PebiBytes,
-)  # noqa: I001
+    TebiBytes,
+)
+from .decimal_memory_size import (
+    GigaBytes,
+    KiloBytes,
+    MegaBytes,
+    PetaBytes,
+    TeraBytes,
+)
+from .memory_size import Bytes, MemorySize

--- a/src/stuom/uom.py
+++ b/src/stuom/uom.py
@@ -3,6 +3,21 @@
 from abc import abstractmethod
 from typing import TypeAlias, TypeVar
 
+HAS_PYDANTIC_CORE = False
+"""Whether the environment is configured with the pydantic_core package installed."""
+
+# Attempt to import pydantic_core, and determine whether validation support is to be added or not.
+try:
+    from collections.abc import Callable
+    from typing import Any
+
+    from pydantic_core import core_schema
+
+    HAS_PYDANTIC_CORE = True
+except ImportError:
+    pass
+
+
 SiT = TypeVar("SiT", bound="HasSiOrder")
 IntT: TypeAlias = int | float
 
@@ -42,6 +57,27 @@ class HasSiOrder(float):
     def __floordiv__(self: SiT, value: IntT) -> SiT:
         self_type = type(self)
         return self_type(float.__floordiv__(self, value))
+
+    if HAS_PYDANTIC_CORE:
+
+        @classmethod
+        def validate(cls, value, _):
+            if not isinstance(value, float):
+                raise TypeError("Must be float")
+
+            return cls(value)
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls,
+            schema: core_schema.CoreSchema,  # type: ignore
+            handler: Callable[[Any], core_schema.CoreSchema],  # type: ignore
+        ) -> core_schema.CoreSchema:  # type: ignore
+            return handler(core_schema.float_schema())
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source, handler):
+            return core_schema.with_info_plain_validator_function(cls.validate)
 
 
 def _convert_si(from_value: HasSiOrder, to_cls: type[SiT]) -> SiT:

--- a/tests/memory_size/test_binary_memory_sizes.py
+++ b/tests/memory_size/test_binary_memory_sizes.py
@@ -1,7 +1,7 @@
 """Test computer memory size units of measurement following the IEC binary convention."""
 
 import pytest
-from stuom.memory_size import (
+from stuom import (
     Bytes,
     GibiBytes,
     KibiBytes,

--- a/tests/memory_size/test_cross_conversions.py
+++ b/tests/memory_size/test_cross_conversions.py
@@ -1,7 +1,7 @@
 """Test computer memory size units of measurement."""
 
 import pytest
-from stuom.memory_size import (
+from stuom import (
     GigaBytes,
     KibiBytes,
     KiloBytes,

--- a/tests/memory_size/test_decimal_memory_sizes.py
+++ b/tests/memory_size/test_decimal_memory_sizes.py
@@ -1,6 +1,6 @@
 """Test computer memory size units of measurement."""
 
-from stuom.memory_size import (
+from stuom import (
     Bytes,
     GigaBytes,
     KiloBytes,

--- a/tests/test_uom_pydantic.py
+++ b/tests/test_uom_pydantic.py
@@ -1,0 +1,21 @@
+"""Test that we can create basic pydantic models using units of measurement."""
+
+import pytest
+from stuom.duration import Seconds
+
+try:
+    from pydantic import BaseModel  # type: ignore
+
+except (ImportError, ModuleNotFoundError):
+    pytest.skip(allow_module_level=True)
+
+
+def test_duration_fields_work_in_pydantic_models():
+    """This ensures that one can construct pydantic `BaseModel`s with the `Duration` units of
+    measurement.
+    """
+
+    class TestModel(BaseModel):
+        duration: Seconds
+
+    TestModel(duration=Seconds(2))


### PR DESCRIPTION
This version of `stuom` mainly adds new units of measurement for measuring computer memory size, namely the `KiloBytes` and `KibiBytes` types. Basic Pydantic supported was added in order to allow for use of `stuom` units in Pydantic `BaseModel`s.

Changes:
- Add international standard units of measurement for measuring computer memory size (#10 )
- Add optional pydantic validation support (#11)
